### PR TITLE
TCO for `formatReports`

### DIFF
--- a/src/Reporter.elm
+++ b/src/Reporter.elm
@@ -317,7 +317,8 @@ formatReportsStartingWith formattedSoFar mode errors =
 
         firstError :: secondError :: restOfErrors ->
             formatReportsStartingWith
-                (formatReportForFileWithExtract mode firstError
+                (formattedSoFar
+                    ++ formatReportForFileWithExtract mode firstError
                     ++ fileSeparator firstError secondError
                 )
                 mode

--- a/src/Reporter.elm
+++ b/src/Reporter.elm
@@ -303,19 +303,25 @@ totalNumberOfErrors errors =
 
 formatReports : Mode -> List ( File, List Error ) -> List Text
 formatReports mode errors =
+    formatReportsStartingWith [] mode errors
+
+
+formatReportsStartingWith : List Text -> Mode -> List ( File, List Error ) -> List Text
+formatReportsStartingWith formattedSoFar mode errors =
     case errors of
         [] ->
-            []
+            formattedSoFar
 
         [ error ] ->
-            formatReportForFileWithExtract mode error
+            formattedSoFar ++ formatReportForFileWithExtract mode error
 
         firstError :: secondError :: restOfErrors ->
-            List.concat
-                [ formatReportForFileWithExtract mode firstError
-                , fileSeparator firstError secondError
-                , formatReports mode (secondError :: restOfErrors)
-                ]
+            formatReportsStartingWith
+                (formatReportForFileWithExtract mode firstError
+                    ++ fileSeparator firstError secondError
+                )
+                mode
+                (secondError :: restOfErrors)
 
 
 fileSeparator : ( File, List Error ) -> ( File, List Error ) -> List Text


### PR DESCRIPTION
I hope this is the right place for this fix.
Running
```
npx elm-review --template jfmengels/elm-review-performance/example
```
reveals that `formatReports` is not tail-call optimized:
> Among other possible reasons, you are applying operations on the result of
recursive call. The recursive call should be the last thing to happen in this
branch.

This PR fixes a stack overflow reported in this issue: https://github.com/jfmengels/node-elm-review/issues/142